### PR TITLE
Update to iOS 9.0 build target

### DIFF
--- a/ATV.podspec
+++ b/ATV.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = "A pluggable table view with a different data source for each section."
   s.homepage     = "https://github.com/pnc/ATV"
 
-  s.license      = 'MIT (example)'
+  s.license      = 'MIT'
   s.author       = { "Phil Calvin" => "pnc1138@gmail.com" }
   s.source       = { :git => "https://github.com/pnc/ATV.git", :branch => "master" }
 

--- a/ATV.podspec
+++ b/ATV.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { "Phil Calvin" => "pnc1138@gmail.com" }
   s.source       = { :git => "https://github.com/pnc/ATV.git", :branch => "master" }
 
-  s.platform     = :ios, '4.3'
+  s.platform     = :ios, '9.0'
   s.framework  = 'CoreData'
   s.requires_arc = true
 

--- a/ATV/ATVArrayTableSection.h
+++ b/ATV/ATVArrayTableSection.h
@@ -17,5 +17,6 @@
 
 - (UITableViewRowAnimation)animationForInsertingObject:(id)object atIndex:(NSUInteger)index;
 - (UITableViewRowAnimation)animationForDeletingObject:(id)object atIndex:(NSUInteger)index;
+- (id)uniqueIdentifierForObject:(id)object;
 
 @end

--- a/ATV/ATVArrayTableSection.h
+++ b/ATV/ATVArrayTableSection.h
@@ -13,4 +13,9 @@
 - (void)setObjects:(NSArray*)objects;
 - (void)setObjects:(NSArray*)objects animated:(BOOL)animated;
 
+#pragma mark - Overrides
+
+- (UITableViewRowAnimation)animationForInsertingObject:(id)object atIndex:(NSUInteger)index;
+- (UITableViewRowAnimation)animationForDeletingObject:(id)object atIndex:(NSUInteger)index;
+
 @end

--- a/ATV/ATVArrayTableSection.m
+++ b/ATV/ATVArrayTableSection.m
@@ -76,17 +76,19 @@
   // if it's not a new entry.
   for (int i = 0; i < oldObjects.count; i++) {
     id item = [oldObjects objectAtIndex:i];
-    NSMutableArray *positions = [oldIndexes objectForKey:item];
+    id identifier = [self uniqueIdentifierForObject:item];
+    NSMutableArray *positions = [oldIndexes objectForKey:identifier];
     if (!positions) {
       positions = [NSMutableArray array];
     }
     [positions addObject:@(i)];
-    [oldIndexes setObject:positions forKey:item];
+    [oldIndexes setObject:positions forKey:identifier];
   }
 
   for (int i = 0; i < objects.count; i++) {
     id item = [objects objectAtIndex:i];
-    NSMutableArray *positions = [oldIndexes objectForKey:item];
+    id identifier = [self uniqueIdentifierForObject:item];
+    NSMutableArray *positions = [oldIndexes objectForKey:identifier];
     NSNumber *oldIndex = nil;
     if (positions.count > 0) {
       // Without loss of generality, assume this duplicate was the first. This
@@ -94,7 +96,7 @@
       oldIndex = [positions objectAtIndex:0];
       [positions removeObjectAtIndex:0];
     } else {
-      [oldIndexes removeObjectForKey:item];
+      [oldIndexes removeObjectForKey:identifier];
     }
 
     NSNumber *newIndex = @(i);
@@ -132,9 +134,8 @@
       [self insertRowsAtIndices:[NSIndexSet indexSetWithIndex:[newIndex unsignedIntegerValue]] withRowAnimation:insertAnimation];
     }
   }
-  NSMutableIndexSet *deleted = [NSMutableIndexSet new];
-  for (id item in oldIndexes) {
-    NSArray <NSNumber *> *indexes = [oldIndexes objectForKey:item];
+  for (id identifier in oldIndexes) {
+    NSArray <NSNumber *> *indexes = [oldIndexes objectForKey:identifier];
     for (NSNumber *index in indexes) {
       id item = [oldObjects objectAtIndex:[index unsignedIntegerValue]];
       UITableViewRowAnimation deleteAnimation = animated ?
@@ -152,6 +153,10 @@
 
 - (UITableViewRowAnimation)animationForDeletingObject:(id)object atIndex:(NSUInteger)index {
   return UITableViewRowAnimationBottom;
+}
+
+- (id)uniqueIdentifierForObject:(id)object {
+  return object;
 }
 
 #pragma mark - Cell source

--- a/ATV/ATVArrayTableSection.m
+++ b/ATV/ATVArrayTableSection.m
@@ -126,6 +126,11 @@
           }
         }
       } else {
+        UITableViewCell *cell = [self cellAtIndex:[oldIndex unsignedIntegerValue]];
+        if (cell) {
+          // Cell is visible, repaint it
+          [self configureCell:cell atIndex:[newIndex unsignedIntegerValue]];
+        }
         [self moveRowAtIndex:[oldIndex unsignedIntegerValue] toIndex:[newIndex unsignedIntegerValue]];
       }
     } else {

--- a/ATV/ATVArrayTableSection.m
+++ b/ATV/ATVArrayTableSection.m
@@ -44,9 +44,6 @@
 }
 
 - (void) setObjects:(NSArray*)objects animated:(BOOL)animated {
-  UITableViewRowAnimation insertAnimation = animated ? UITableViewRowAnimationTop : UITableViewRowAnimationNone;
-  UITableViewRowAnimation deleteAnimation = animated ? UITableViewRowAnimationBottom : UITableViewRowAnimationNone;
-
   if (!_objects) {
     _objects = objects;
     [self reloadSectionWithRowAnimation:UITableViewRowAnimationNone];
@@ -130,6 +127,8 @@
         [self moveRowAtIndex:[oldIndex unsignedIntegerValue] toIndex:[newIndex unsignedIntegerValue]];
       }
     } else {
+      UITableViewRowAnimation insertAnimation = animated ?
+      [self animationForInsertingObject:item atIndex:[newIndex unsignedIntegerValue]] : UITableViewRowAnimationNone;
       [self insertRowsAtIndices:[NSIndexSet indexSetWithIndex:[newIndex unsignedIntegerValue]] withRowAnimation:insertAnimation];
     }
   }
@@ -137,11 +136,22 @@
   for (id item in oldIndexes) {
     NSArray <NSNumber *> *indexes = [oldIndexes objectForKey:item];
     for (NSNumber *index in indexes) {
-      [deleted addIndex:[index unsignedIntegerValue]];
+      id item = [oldObjects objectAtIndex:[index unsignedIntegerValue]];
+      UITableViewRowAnimation deleteAnimation = animated ?
+      [self animationForDeletingObject:item atIndex:[index unsignedIntegerValue]] : UITableViewRowAnimationNone;
+      [self deleteRowsAtIndices:[NSIndexSet indexSetWithIndex:[index unsignedIntegerValue]]
+               withRowAnimation:deleteAnimation];
     }
   }
-  [self deleteRowsAtIndices:deleted withRowAnimation:deleteAnimation];
   [self endUpdates];
+}
+
+- (UITableViewRowAnimation)animationForInsertingObject:(id)object atIndex:(NSUInteger)index {
+  return UITableViewRowAnimationTop;
+}
+
+- (UITableViewRowAnimation)animationForDeletingObject:(id)object atIndex:(NSUInteger)index {
+  return UITableViewRowAnimationBottom;
 }
 
 #pragma mark - Cell source

--- a/ATV/ATVTableSection.h
+++ b/ATV/ATVTableSection.h
@@ -80,4 +80,7 @@
                 toIndex:(NSUInteger)newIndex;
 - (void) reloadSectionWithRowAnimation:(UITableViewRowAnimation)animation;
 
+- (void)setNeedsToPerformUpdates;
+- (void)performUpdatesAnimated:(BOOL)animated;
+
 @end

--- a/ATV/ATVTableSection.m
+++ b/ATV/ATVTableSection.m
@@ -1,6 +1,7 @@
 #import "ATVTableSection.h"
 #import "ATVTableSection_Private.h"
 #import "ATVTableView.h"
+#import "ATVTableView_Private.h"
 
 @implementation ATVTableSection
 
@@ -200,6 +201,17 @@
 
 - (void) deselectRowAtIndex:(NSUInteger)index animated:(BOOL)animated {
   [self._tableView deselectRowAtIndex:index inSection:self animated:animated];
+}
+
+#pragma mark - Deferred updates
+
+- (void)setNeedsToPerformUpdates {
+  self.needsToPerformUpdates = YES;
+  [self._tableView setWillPerformUpdates];
+}
+
+- (void)performUpdatesAnimated:(BOOL)animated {
+  self.needsToPerformUpdates = NO;
 }
 
 @end

--- a/ATV/ATVTableSection_Private.h
+++ b/ATV/ATVTableSection_Private.h
@@ -15,4 +15,5 @@
 @interface ATVTableSection ()
 @property (ATV_WEAK) ATVTableView* _tableView;
 @property (strong) NSMutableDictionary* registeredNibs;
+@property BOOL needsToPerformUpdates;
 @end

--- a/ATV/ATVTableSection_Private.h
+++ b/ATV/ATVTableSection_Private.h
@@ -1,19 +1,8 @@
 #import "ATVTableSection.h"
 
 @class ATVTableView;
-
-#ifndef ATV_WEAK
-#if __has_feature(objc_arc_weak)
-#define ATV_WEAK weak
-#elif __has_feature(objc_arc)
-#define ATV_WEAK unsafe_unretained
-#else
-#define ATV_WEAK assign
-#endif
-#endif
-
 @interface ATVTableSection ()
-@property (ATV_WEAK) ATVTableView* _tableView;
+@property (weak) ATVTableView* _tableView;
 @property (strong) NSMutableDictionary* registeredNibs;
 @property BOOL needsToPerformUpdates;
 @end

--- a/ATV/ATVTableView.h
+++ b/ATV/ATVTableView.h
@@ -25,6 +25,10 @@
 @property (nonatomic, strong) UIView* emptyView;
 @property (nonatomic) BOOL emptyViewHonorsContentInset;
 
+#pragma mark - Deferred updates
+
+- (void)performUpdatesAnimated:(BOOL)animated;
+
 #pragma mark - Private
 
 - (UITableViewCell*) cellForRowAtIndex:(NSUInteger)index inSection:(ATVTableSection*)section;

--- a/ATV/ATVTableView_Private.h
+++ b/ATV/ATVTableView_Private.h
@@ -5,4 +5,7 @@
 @property (strong) NSMutableArray* sections;
 @property UITableViewCellSeparatorStyle desiredSeparatorStyle;
 
+@property BOOL willPerformUpdates;
+- (void)setWillPerformUpdates;
+
 @end


### PR DESCRIPTION
Previously, we were using unsafe_unretained references for ATVTableViewSection's _tableView property because the build target was set to such an old version. This should Increase Memory Safety by using a real weak reference.